### PR TITLE
Add perl script for magetab (IDF+SDRF) validation

### DIFF
--- a/.github/workflows/validate-all.yml
+++ b/.github/workflows/validate-all.yml
@@ -16,8 +16,24 @@ on:
       - cron: '0 0 * * *'
 
 jobs:
+  perl_validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup conda
+        uses: s-weigand/setup-conda@v1
+        with:
+          update-conda: true
+          conda-channels: anaconda, conda-forge
+      - name: Install perl-atlas-modules
+        run: conda create -n perl-atlas perl-atlas-modules
+      - name: Run validation script
+        run: |
+          conda activate perl-atlas
+          for idf_file in $(ls path/to/idfs); do
+            perl validate_magetab.pl $idf_file
+          done
   build:
-
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/validate_magetab.pl
+++ b/validate_magetab.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+#
+# This script parsed MAGE-TAB for a given experiment idf
+#
+# It requires the conda perl-atlas-modules package to be installed
+
+use strict;
+use warnings;
+use 5.10.0;
+
+# MAGE-TAB parsing.
+use Atlas::Magetab4Atlas;
+
+my $magetab4atlas = Atlas::Magetab4Atlas->new( "idf_filename" => $ARGV[0] );
+
+print "Accession:".$magetab4atlas;
+
+foreach my $assay4atlas (@{ $magetab4atlas->get_assays }) {
+  # Get assay name
+  print "Assay:".$assay4atlas->get_name;
+}


### PR DESCRIPTION
This PR adds a validation script that takes initial step that Perl microarray processing scripts take to deal with metadata. The main objective is to make the MAGE-TAB files go through the MAGE-TAB package reader (https://metacpan.org/pod/Bio::MAGETAB::Util::Reader).